### PR TITLE
Optimize functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 FROM alpine:3.18.4
 
 LABEL maintainer="Michael Oberdorf IT-Consulting <info@oberdorf-itc.de>"
-LABEL site.local.program.version="0.0.1"
+LABEL site.local.program.version="1.0.1"
 
 ENV MQTT_SERVER=localhost \
     MQTT_PORT=1883 \
     MQTT_TLS_enabled=false \
-    MQTT_TLS_no_hostname_validation=false
+    MQTT_TLS_no_hostname_validation=false \
+    MQTT_RETAIN=false
 
 RUN apk upgrade --available --no-cache --update \
     && apk add --no-cache --update \
        speedtest-cli=2.1.3-r5 \
        mosquitto-clients=2.0.18-r0 \
-       bash=5.2.15-r5
+       bash=5.2.15-r5 \
+       jq=1.6-r3 \
+       ca-certificates=20230506-r0
 
 COPY --chown=root:root /src /
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source code: [GitHub](https://github.com/cybcon/docker.speedtest2mqtt)
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.0.0`](https://github.com/cybcon/docker.speedtest2mqtt/blob/v1.0.0/Dockerfile)
+* [`latest`, `1.0.1`](https://github.com/cybcon/docker.speedtest2mqtt/blob/v1.0.1/Dockerfile)
 
 # Summary
 
@@ -25,12 +25,14 @@ The container grab the configuration via environment variables.
 | Environment variable name | Description | Required | Default value |
 |--|--|--|--|
 | `MQTT_SERVER` | The MQTT server hostname or IP address | **OPTIONAL** | `localhost` |
-| `MQTT_TLS_enabled` | Should SSL communication be enabled (`true`) or not (`false`) | **OPTIONAL** | `false` |
 | `MQTT_PORT` | The TCP port of the MQTT server | **OPTIONAL** | `1883` |
+| `MQTT_TLS_enabled` | Should SSL communication be enabled (`true`) or not (`false`) | **OPTIONAL** | `false` |
+| `MQTT_CACERT_FILE` | If TLS is enabled, the path to the CA certificate file to validate the MQTT server certificate | **OPTIONAL** | |
 | `MQTT_TLS_no_hostname_validation` | If TLS is enabled, skip the hostname validation of the TLS certificate | `false` |
 | `MQTT_USER` | The MQTT username for MQTT authentication | **OPTIONAL** | |
 | `MQTT_PASSWORD_FILE` | The filepath where the MQTT password is stored for MQTT authentication | **OPTIONAL** | |
 | `MQTT_TOPIC` | The MQTT topic to send the speedtest results to | **MANDATORY** | |
+| `MQTT_RETAIN`| Set the retain flag when publishing the speedtest result to MQTT topic | **OPTIONAL** | `false` |
 | `FREQUENCE` | Time in seconds between speedtests. If nothing is given, the container stops after 1 speedtest | **OPTIONAL** | |
 
 # Docker compose configuration

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -242,6 +242,7 @@ do
   fi
 
   if [ ! -z "${FREQUENCE}" ]; then
+    echo "Sleeping ${FREQUENCE} seconds"
     sleep ${FREQUENCE}
   else
     break

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -7,15 +7,15 @@
 # Author: Michael Oberdorf
 # Date:   2023-10-27
 # Last changed by: Michael Oberdorf
-# Last changed at: 2023-10-27
+# Last changed at: 2023-10-28
 ##############################################################################
 
 #-----------------------------------------------------------------------------
 # Global configuration
 #-----------------------------------------------------------------------------
-set -eo pipefail
-
-VERSION="0.0.1"
+VERSION="1.0.1"
+ERROR_SLEEP_SECONDS=60
+CACERT_SYSTEM_PATH='/usr/share/ca-certificates'
 
 # Set default values
 if [ -z "${MQTT_SERVER}" ]; then
@@ -29,6 +29,9 @@ if [ -z "${MQTT_TLS_enabled}" ]; then
 fi
 if [ -z "${MQTT_TLS_no_hostname_validation}" ]; then
   MQTT_TLS_no_hostname_validation='false'
+fi
+if [ -z "${MQTT_RETAIN}" ]; then
+  MQTT_RETAIN='false'
 fi
 MQTT_PASSWORD=''
 
@@ -117,6 +120,13 @@ function validate_input_parameters {
     MQTT_TLS_no_hostname_validation=$(validate_boolean ${MQTT_TLS_no_hostname_validation})
   fi
 
+  if [ -z "$(validate_boolean ${MQTT_RETAIN})" ]; then
+    echo "ERROR: Environment variable 'MQTT_RETAIN' needs to be 'true' or 'false' (but is ${MQTT_RETAIN})!" >&2
+    exit 1
+  else
+    MQTT_RETAIN=$(validate_boolean ${MQTT_RETAIN})
+  fi
+
   if [ ! -z "${MQTT_PORT}" ]; then
     if [ "$(is_int ${MQTT_PORT})" == "false" ]; then
       echo "ERROR: Given MQTT Port (${MQTT_PORT}) is no integer!" >&2
@@ -145,6 +155,13 @@ function validate_input_parameters {
     fi
   fi
 
+  if [ ! -z "${MQTT_CACERT_FILE}" ]; then
+    if [ ! -f "${MQTT_CACERT_FILE}" -a ! -d "${MQTT_CACERT_FILE}" ]; then
+      echo "ERROR: File not found exception for MQTT_CACERT_FILE=${MQTT_CACERT_FILE}!" >&2
+      exit 1
+    fi
+  fi
+
   if [ -z "${MQTT_TOPIC}" ]; then
     echo "ERROR: MQTT_TOPIC not defined. This parameter is mandatory!" >&2
     exit 1
@@ -157,7 +174,7 @@ function validate_input_parameters {
 # @return: string, json output
 #-----------------------------------------------------------------------------
 function do_speedtest {
-  speedtest-cli --json
+  speedtest-cli --json | jq 2>/dev/null
 }
 
 #-----------------------------------------------------------------------------
@@ -172,14 +189,34 @@ function publish_result {
   if [ ! -z "${MQTT_USER}" -a ! -z "${MQTT_PASSWORD}" ]; then
     CREENTIALS="--username \"${MQTT_USER}\" --pw \"${MQTT_PASSWORD}\""
   fi
-  INSECURE=''
-  if [ "${MQTT_TLS_no_hostname_validation}" == "true" ]; then
-    INSECURE='--insecure'
+  RETAIN=''
+  if [ "${MQTT_RETAIN}" == "true" ]; then
+    RETAIN='--retain'
   fi
 
-  echo "${data}" |  mosquitto_pub --host ${MQTT_SERVER} --port ${MQTT_PORT} ${CREDENTIALS} --topic ${MQTT_TOPIC} ${INSECURE} --retain --stdin-file
+  TLS=''
+  if [ "${MQTT_TLS_enabled}" == "true" ]; then
+    CACERT=''
+    if [ ! -z "${MQTT_CACERT_FILE}" ]; then
+      if [ -f "${MQTT_CACERT_FILE}" ]; then
+        CACERT="--cafile \"${MQTT_CACERT_FILE}\""
+      elif [ -f "${MQTT_CACERT_FILE}" ]; then
+        CACERT="--capath \"${MQTT_CACERT_FILE}\""
+      fi
+    else
+      CACERT="--capath \"${CACERT_SYSTEM_PATH}\""
+    fi
 
-#| `MQTT_TLS_enabled` | Should SSL communication be enabled (`true`) or not (`false`) | **OPTIONAL** | `false` |
+    INSECURE=''
+    if [ "${MQTT_TLS_no_hostname_validation}" == "true" ]; then
+      CACERT=''
+      INSECURE='--insecure'
+    fi
+
+    TLS="${INSECURE} ${CACERT}"
+  fi
+
+  echo "${data}" |  mosquitto_pub --host ${MQTT_SERVER} --port ${MQTT_PORT} ${CREDENTIALS} --topic ${MQTT_TOPIC} ${TLS} ${RETAIN} --stdin-file
 }
 
 
@@ -193,9 +230,15 @@ validate_input_parameters
 
 while true
 do
+  echo "Trigger Speedtest"
   result=$(do_speedtest)
   if [ ! -z "${result}" ]; then
+    echo "Publish speedtest rresult via MQTT"
     publish_result "${result}"
+  else
+    echo "WARNING: Speedtest without correct json output. Sleep ${ERROR_SLEEP_SECONDS} and try again"
+    sleep ${ERROR_SLEEP_SECONDS}
+    continue
   fi
 
   if [ ! -z "${FREQUENCE}" ]; then


### PR DESCRIPTION
# Summary

# Enhancements
- Add `jq` to validate speedtest-cli output
- Add `ca-certificates` package to validate TLS connection to MQTT if no other certificate is provided
- Add flag `MQTT_RETAIN` to control if the messages should be published with retain flag or not

## Fixes
- TLS functionality
- Version Number